### PR TITLE
Track upgrade-driven expenses

### DIFF
--- a/app/game/components/tabs/FinanceTab.tsx
+++ b/app/game/components/tabs/FinanceTab.tsx
@@ -4,7 +4,16 @@ import React from 'react';
 import { useFinanceData } from '@/hooks/useFinanceData';
 
 export function FinanceTab() {
-  const { metrics, weeklyHistory, totalProfit, lastWeek } = useFinanceData();
+  const {
+    metrics,
+    weeklyHistory,
+    totalProfit,
+    lastWeek,
+    weeklyExpenses,
+    baseWeeklyExpenses,
+    upgradeWeeklyExpenses,
+    otherWeeklyExpenses,
+  } = useFinanceData();
 
   return (
     <div>
@@ -47,6 +56,16 @@ export function FinanceTab() {
             <div className="text-red-300 text-xs">
               {lastWeek ? `Week ${lastWeek.week}: $${lastWeek.expenses}` : 'No data yet'}
             </div>
+            <div className="text-red-300 text-xs mt-2">
+              Current weekly burn: ${weeklyExpenses}
+            </div>
+            <div className="text-red-300 text-xs">Base ${baseWeeklyExpenses}</div>
+            <div className="text-red-300 text-xs">
+              Upgrades {upgradeWeeklyExpenses > 0 ? `+$${upgradeWeeklyExpenses}` : '$0'}
+            </div>
+            {otherWeeklyExpenses > 0 && (
+              <div className="text-red-300 text-xs">Other +${otherWeeklyExpenses}</div>
+            )}
           </div>
         </div>
         

--- a/hooks/useFinanceData.ts
+++ b/hooks/useFinanceData.ts
@@ -1,16 +1,30 @@
 import { useGameStore } from '@/lib/store/gameStore';
+import { calculateUpgradeWeeklyExpenses, getWeeklyBaseExpenses } from '@/lib/features/economy';
 
 /**
  * Custom hook for accessing finance-related data from the game store.
  * Used by components that need metrics and weekly history data.
  */
 export const useFinanceData = () => {
-  const { metrics, weeklyHistory, weeklyExpenses } = useGameStore();
-  
+  const { metrics, weeklyHistory, weeklyExpenses, upgrades, selectedIndustry } = useGameStore();
+  const industryId = selectedIndustry?.id ?? 'dental';
+  const baseWeeklyExpenses = getWeeklyBaseExpenses();
+  const upgradeWeeklyExpenses = Math.max(
+    calculateUpgradeWeeklyExpenses(upgrades, industryId),
+    0
+  );
+  const otherWeeklyExpenses = Math.max(
+    weeklyExpenses - (baseWeeklyExpenses + upgradeWeeklyExpenses),
+    0
+  );
+
   return {
     metrics,
     weeklyHistory,
-    weeklyExpenses, // Current weekly expenses
+    weeklyExpenses, // Current weekly expenses (base + upgrade-driven)
+    baseWeeklyExpenses,
+    upgradeWeeklyExpenses,
+    otherWeeklyExpenses,
     // Helper: Get the most recent week's data
     lastWeek: weeklyHistory.length > 0 ? weeklyHistory[weeklyHistory.length - 1] : null,
     // Helper: Calculate total profit

--- a/lib/features/economy.test.ts
+++ b/lib/features/economy.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { endOfWeek, getWeeklyBaseExpenses } from './economy';
+
+test('endOfWeek reflects higher expenses after upgrades increase weekly costs', () => {
+  const baseWeeklyExpenses = getWeeklyBaseExpenses();
+  const baseResult = endOfWeek(5000, 2000, baseWeeklyExpenses, 0);
+
+  const upgradeDelta = 200;
+  const upgradedWeeklyExpenses = baseWeeklyExpenses + upgradeDelta;
+  const upgradedResult = endOfWeek(5000, 2000, upgradedWeeklyExpenses, 0);
+
+  assert.equal(
+    upgradedResult.totalExpenses,
+    baseResult.totalExpenses + upgradeDelta,
+    'total expenses should include the upgrade delta'
+  );
+  assert.equal(
+    upgradedResult.profit,
+    baseResult.profit - upgradeDelta,
+    'profit should drop by the upgrade delta'
+  );
+  assert.equal(
+    upgradedResult.additionalExpenses,
+    upgradedWeeklyExpenses - baseWeeklyExpenses,
+    'additional expenses should match the difference between upgraded and base expenses'
+  );
+});

--- a/lib/store/types.ts
+++ b/lib/store/types.ts
@@ -48,7 +48,8 @@ export interface GameState {
   weeklyExpenses: number;
   weeklyOneTimeCosts: number; // One-time costs (events, marketing campaigns, etc.)
   weeklyHistory: WeeklyHistoryEntry[];
-  
+  weeklyExpenseAdjustments: number;
+
   // Customers
   customers: Customer[];
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --loader ts-node/esm --test \"lib/**/*.test.ts\""
   },
   "dependencies": {
     "next": "15.5.4",
@@ -23,6 +24,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
     "tailwindcss": "^4",
+    "ts-node": "^10",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- update the economy and game slices to carry upgrade-driven weekly expenses, including a helper to compute upgrade costs and reset logic between weeks
- increment recurring expenses when upgrades are purchased and surface the breakdown through the finance hook and tab UI
- add a regression test for `endOfWeek` and wire an npm test script for the new coverage

## Testing
- `npm test` *(fails: ts-node package cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e241196fb883249026bd47ba55a6cc