### PR TITLE
Improve GameButton responsiveness

### DIFF
--- a/app/components/ui/GameButton.css
+++ b/app/components/ui/GameButton.css
@@ -1,19 +1,30 @@
 .game-btn {
     font-family: var(--font-open-sans), 'Arial', sans-serif;
-    font-size: 28px;
+    font-size: clamp(1rem, 0.8rem + 1vw, 1.6rem);
     font-weight: 800;
-  
-    padding: 14px 40px;
-    border-radius: 14px;
+    line-height: 1.1;
+    padding: clamp(0.65rem, 0.55rem + 0.6vw, 0.9rem) clamp(1.2rem, 0.95rem + 2.4vw, 2.7rem);
+    border-radius: clamp(0.75rem, 0.7rem + 0.4vw, 1.05rem);
     position: relative;
     cursor: pointer;
-  
-    transition: transform 0.1s, box-shadow 0.1s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
+    text-align: center;
+    white-space: normal;
+    text-wrap: balance;
+    box-sizing: border-box;
+    max-width: min(100%, 22rem);
+    width: 100%;
+    min-height: clamp(2.75rem, 2.2rem + 1vw, 3.4rem);
+    transition: transform 0.1s, box-shadow 0.1s, filter 0.2s;
     border: 4px solid #000; /* thick black outline */
     overflow: hidden;
     z-index: 1;
+    touch-action: manipulation;
   }
-  
+
   /* 🔵 Blue button variant */
   .game-btn.blue {
     --text-stroke: #23AAF6;
@@ -79,17 +90,34 @@
   }
   
   /* Pressed states */
-  .game-btn.blue:active {
+  .game-btn.blue:active:not(:disabled) {
     transform: translateY(3px);
     box-shadow: 0 3px 0 rgba(0, 0, 0, 0.6),
                 inset 0 -3px 0 #1057DA,
                 inset 0 3px 0 #23AAF6;
   }
-  
-  .game-btn.gold:active {
+
+  .game-btn.gold:active:not(:disabled) {
     transform: translateY(3px);
     box-shadow: 0 3px 0 rgba(0, 0, 0, 0.6),
                 inset 0 -3px 0 #B87333,
                 inset 0 3px 0 #FFA402;
+  }
+
+  .game-btn:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.9);
+    outline-offset: 3px;
+  }
+
+  .game-btn:disabled {
+    cursor: not-allowed;
+    filter: saturate(0.75) brightness(0.95);
+    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.45), inset 0 -2px 0 rgba(0, 0, 0, 0.35);
+  }
+
+  @media (min-width: 640px) {
+    .game-btn {
+      width: auto;
+    }
   }
   

--- a/app/components/ui/GameButton.tsx
+++ b/app/components/ui/GameButton.tsx
@@ -8,12 +8,27 @@ type GameButtonProps = {
   color?: "blue" | "gold";
   href?: string;
   onClick?: () => void;
+  className?: string;
+  disabled?: boolean;
+  type?: "button" | "submit" | "reset";
 };
 
-export default function GameButton({ children, color = "blue", href, onClick }: GameButtonProps) {
+export default function GameButton({
+  children,
+  color = "blue",
+  href,
+  onClick,
+  className,
+  disabled = false,
+  type = "button",
+}: GameButtonProps) {
   const router = useRouter();
 
   const handleClick = () => {
+    if (disabled) {
+      return;
+    }
+
     if (href) {
       // delay for press animation
       setTimeout(() => router.push(href), 120);
@@ -22,8 +37,18 @@ export default function GameButton({ children, color = "blue", href, onClick }: 
     }
   };
 
+  const classes = ["game-btn", color, "text-stroke", className]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <button className={`game-btn ${color} text-stroke`} onClick={handleClick}>
+    <button
+      type={type}
+      className={classes}
+      onClick={handleClick}
+      disabled={disabled}
+      aria-disabled={disabled}
+    >
       {children}
     </button>
   );

--- a/app/game/components/tabs/UpgradesTab.tsx
+++ b/app/game/components/tabs/UpgradesTab.tsx
@@ -117,6 +117,7 @@ export function UpgradesTab() {
             const owned = purchased.has(upgrade.id);
             const canAfford = canAffordUpgrade(upgrade.cost);
             const effects = upgrade.effects.map(formatEffect);
+            const buttonDisabled = owned || !canAfford;
             return (
               <div
                 key={upgrade.id}
@@ -147,8 +148,10 @@ export function UpgradesTab() {
                 <div className="mt-4 flex justify-end">
                   <GameButton
                     color={owned ? 'gold' : canAfford ? 'blue' : 'gold'}
+                    className="w-full sm:w-auto"
+                    disabled={buttonDisabled}
                     onClick={() => {
-                      if (!owned && canAfford) {
+                      if (!buttonDisabled) {
                         handlePurchase(upgrade.id);
                       }
                     }}


### PR DESCRIPTION
## Summary
- add flexibility to GameButton with optional props and disabled click handling
- refresh GameButton styling with fluid sizing, focus-visible, and disabled treatments to keep the design responsive
- update the upgrades tab to use the responsive button layout and disable unaffordable or purchased upgrades

## Testing
- npm run lint *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68e3562242048324b04b6fc98bb400d8