### PR TITLE
Add grid pathfinding and prevent waiting seat overlap

### DIFF
--- a/lib/game/config.ts
+++ b/lib/game/config.ts
@@ -34,6 +34,34 @@ export const BUSINESS_STATS = {
 } as const;
 
 // -----------------------------------------------------------------------------
+// MAP CONFIGURATION
+// -----------------------------------------------------------------------------
+
+export interface MapWall {
+  x: number;
+  y: number;
+}
+
+export interface MapConfig {
+  width: number;
+  height: number;
+  walls: MapWall[];
+}
+
+export const MAP_CONFIG: MapConfig = {
+  width: 10,
+  height: 10,
+  // Walls are defined using zero-based grid coordinates within the map bounds.
+  // Negative coordinates are not allowed – keep values between 0 and width/height - 1.
+  walls: [
+    { x: 3, y: 1 },
+    { x: 3, y: 2 },
+    { x: 3, y: 3 },
+    { x: 3, y: 4 },
+  ],
+};
+
+// -----------------------------------------------------------------------------
 // CORE GAME TIMING (derived from BUSINESS_STATS)
 // -----------------------------------------------------------------------------
 

--- a/lib/game/pathfinding.ts
+++ b/lib/game/pathfinding.ts
@@ -1,0 +1,94 @@
+import type { GridPosition } from './positioning';
+import { MAP_CONFIG, type MapConfig } from './config';
+
+const DIRECTIONS: GridPosition[] = [
+  { x: 1, y: 0 },
+  { x: -1, y: 0 },
+  { x: 0, y: 1 },
+  { x: 0, y: -1 },
+];
+
+const serialize = (position: GridPosition): string => `${position.x},${position.y}`;
+
+const isWithinBounds = (position: GridPosition, config: MapConfig): boolean => {
+  return (
+    position.x >= 0 &&
+    position.x < config.width &&
+    position.y >= 0 &&
+    position.y < config.height
+  );
+};
+
+const createWallSet = (config: MapConfig): Set<string> => {
+  return new Set(config.walls.map(serialize));
+};
+
+/**
+ * Simple breadth-first search pathfinding on the tile grid.
+ * Returns an ordered list of waypoints (excluding the starting tile, including the goal).
+ */
+export function findPath(
+  start: GridPosition,
+  goal: GridPosition,
+  config: MapConfig = MAP_CONFIG
+): GridPosition[] {
+  if (start.x === goal.x && start.y === goal.y) {
+    return [];
+  }
+
+  const walls = createWallSet(config);
+  const startKey = serialize(start);
+  const goalKey = serialize(goal);
+
+  const queue: GridPosition[] = [start];
+  const cameFrom = new Map<string, string | null>([[startKey, null]]);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const currentKey = serialize(current);
+
+    if (currentKey === goalKey) {
+      break;
+    }
+
+    for (const direction of DIRECTIONS) {
+      const next: GridPosition = {
+        x: current.x + direction.x,
+        y: current.y + direction.y,
+      };
+
+      const nextKey = serialize(next);
+
+      if (!isWithinBounds(next, config)) {
+        continue;
+      }
+
+      if (walls.has(nextKey)) {
+        continue;
+      }
+
+      if (cameFrom.has(nextKey)) {
+        continue;
+      }
+
+      queue.push(next);
+      cameFrom.set(nextKey, currentKey);
+    }
+  }
+
+  if (!cameFrom.has(goalKey)) {
+    return [];
+  }
+
+  // Reconstruct path from goal to start
+  const path: GridPosition[] = [];
+  let currentKey: string | null = goalKey;
+
+  while (currentKey && currentKey !== startKey) {
+    const [x, y] = currentKey.split(',').map(Number);
+    path.push({ x, y });
+    currentKey = cameFrom.get(currentKey) ?? null;
+  }
+
+  return path.reverse();
+}


### PR DESCRIPTION
## Summary
- define tile-based map configuration with wall coordinates and expose a reusable BFS pathfinder
- track waiting seat occupancy precisely and assign chair/service targets with obstacle-aware paths
- update customer movement to follow multi-step paths without stacking on occupied chairs

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e37cd7427c83249c9956679b097341