### PR TITLE
Fix customer facing direction and block occupied seats

### DIFF
--- a/app/game/components/canvas/SpriteCustomer.tsx
+++ b/app/game/components/canvas/SpriteCustomer.tsx
@@ -19,43 +19,28 @@ export function SpriteCustomer({ customer, scaleFactor }: SpriteCustomerProps) {
   const gridX = Math.floor(customer.x);
   const gridY = Math.floor(customer.y);
   
-  // Determine walking direction based on target position
-  const getWalkingDirection = (): 'down' | 'left' | 'up' | 'right' => {
-    if (customer.targetX === undefined || customer.targetY === undefined) {
-      return 'down';
-    }
-    
-    const dx = customer.targetX - customer.x;
-    const dy = customer.targetY - customer.y;
-    
-    // Determine primary direction (larger movement axis)
-    if (Math.abs(dx) > Math.abs(dy)) {
-      return dx > 0 ? 'right' : 'left';
-    } else {
-      return dy > 0 ? 'down' : 'up';
-    }
-  };
-  
   // Determine animation state based on customer status
   const getAnimationState = () => {
+    const facingDirection = customer.facingDirection ?? 'down';
+
     switch (customer.status) {
       case CustomerStatus.Spawning:
-        return { isWalking: false, isCelebrating: false, direction: 'down' as const };
-      
+        return { isWalking: false, isCelebrating: false, direction: facingDirection };
+
       case CustomerStatus.WalkingToChair:
       case CustomerStatus.WalkingToRoom:
-        return { isWalking: true, isCelebrating: false, direction: getWalkingDirection() };
-      
+        return { isWalking: true, isCelebrating: false, direction: facingDirection };
+
       case CustomerStatus.LeavingAngry:
-        return { isWalking: true, isCelebrating: false, direction: 'down' as const };
-      
+        return { isWalking: true, isCelebrating: false, direction: facingDirection };
+
       case CustomerStatus.WalkingOutHappy:
-        return { isWalking: false, isCelebrating: true, direction: 'down' as const };
-      
+        return { isWalking: false, isCelebrating: true, direction: facingDirection };
+
       case CustomerStatus.Waiting:
       case CustomerStatus.InService:
       default:
-        return { isWalking: false, isCelebrating: false, direction: 'down' as const };
+        return { isWalking: false, isCelebrating: false, direction: facingDirection };
     }
   };
 

--- a/lib/game/config.ts
+++ b/lib/game/config.ts
@@ -34,6 +34,34 @@ export const BUSINESS_STATS = {
 } as const;
 
 // -----------------------------------------------------------------------------
+// MAP CONFIGURATION
+// -----------------------------------------------------------------------------
+
+export interface MapWall {
+  x: number;
+  y: number;
+}
+
+export interface MapConfig {
+  width: number;
+  height: number;
+  walls: MapWall[];
+}
+
+export const MAP_CONFIG: MapConfig = {
+  width: 10,
+  height: 10,
+  // Walls are defined using zero-based grid coordinates within the map bounds.
+  // Negative coordinates are not allowed – keep values between 0 and width/height - 1.
+  walls: [
+    { x: 3, y: 1 },
+    { x: 3, y: 2 },
+    { x: 3, y: 3 },
+    { x: 3, y: 4 },
+  ],
+};
+
+// -----------------------------------------------------------------------------
 // CORE GAME TIMING (derived from BUSINESS_STATS)
 // -----------------------------------------------------------------------------
 

--- a/lib/game/pathfinding.ts
+++ b/lib/game/pathfinding.ts
@@ -1,0 +1,108 @@
+import type { GridPosition } from './positioning';
+import { MAP_CONFIG, type MapConfig } from './config';
+
+interface FindPathOptions {
+  mapConfig?: MapConfig;
+  additionalWalls?: GridPosition[];
+  allowGoalOccupied?: boolean;
+}
+
+const DIRECTIONS: GridPosition[] = [
+  { x: 1, y: 0 },
+  { x: -1, y: 0 },
+  { x: 0, y: 1 },
+  { x: 0, y: -1 },
+];
+
+const serialize = (position: GridPosition): string => `${position.x},${position.y}`;
+
+const isWithinBounds = (position: GridPosition, config: MapConfig): boolean => {
+  return (
+    position.x >= 0 &&
+    position.x < config.width &&
+    position.y >= 0 &&
+    position.y < config.height
+  );
+};
+
+const createWallSet = (config: MapConfig, additionalWalls: GridPosition[]): Set<string> => {
+  const serializedWalls = [
+    ...config.walls.map(serialize),
+    ...additionalWalls.map(serialize),
+  ];
+
+  return new Set(serializedWalls);
+};
+
+/**
+ * Simple breadth-first search pathfinding on the tile grid.
+ * Returns an ordered list of waypoints (excluding the starting tile, including the goal).
+ */
+export function findPath(
+  start: GridPosition,
+  goal: GridPosition,
+  options: FindPathOptions = {}
+): GridPosition[] {
+  if (start.x === goal.x && start.y === goal.y) {
+    return [];
+  }
+
+  const config = options.mapConfig ?? MAP_CONFIG;
+  const allowGoalOccupied = options.allowGoalOccupied ?? true;
+  const additionalWalls = options.additionalWalls ?? [];
+  const walls = createWallSet(config, additionalWalls);
+  const startKey = serialize(start);
+  const goalKey = serialize(goal);
+
+  const queue: GridPosition[] = [start];
+  const cameFrom = new Map<string, string | null>([[startKey, null]]);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const currentKey = serialize(current);
+
+    if (currentKey === goalKey) {
+      break;
+    }
+
+    for (const direction of DIRECTIONS) {
+      const next: GridPosition = {
+        x: current.x + direction.x,
+        y: current.y + direction.y,
+      };
+
+      const nextKey = serialize(next);
+
+      if (!isWithinBounds(next, config)) {
+        continue;
+      }
+
+      if (walls.has(nextKey) && !(allowGoalOccupied && nextKey === goalKey)) {
+        continue;
+      }
+
+      if (cameFrom.has(nextKey)) {
+        continue;
+      }
+
+      queue.push(next);
+      cameFrom.set(nextKey, currentKey);
+    }
+  }
+
+  if (!cameFrom.has(goalKey)) {
+    return [];
+  }
+
+  // Reconstruct path from goal to start
+  const path: GridPosition[] = [];
+  let currentKey: string | null = goalKey;
+
+  while (currentKey && currentKey !== startKey) {
+    const [x, y] = currentKey.split(',').map(Number);
+    path.push({ x, y });
+    currentKey = cameFrom.get(currentKey) ?? null;
+  }
+
+  return path.reverse();
+}


### PR DESCRIPTION
## Summary
- track each customer's facing direction during movement and drive sprite animations from that state
- allow pathfinding to accept dynamic walls so occupied waiting chairs are treated as impassable to other customers
- route customers to chairs and rooms using the updated pathfinder while keeping waiting seats reserved

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e37cd7427c83249c9956679b097341